### PR TITLE
Loosen required versions

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,7 +1,7 @@
-matplotlib==3.3.4
-numpy==1.19.5
-pandas==1.1.5
-torch==1.12.1
-tensorboard==2.5.0
-torchvision==0.13.1
+matplotlib>=3.3.4, <=4.0.0
+numpy>=1.19.5, <=2.0.0
+pandas>=1.1.5, <=2.0.0
+torch==1.12.*
+tensorboard>=2.5.0, <=3.0.0
+torchvision==0.13.*
 wget==3.2

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,7 +1,7 @@
 matplotlib==3.3.4
 numpy==1.19.5
 pandas==1.1.5
-torch==1.8.1
+torch==1.12.1
 tensorboard==2.5.0
-torchvision==0.9.1
+torchvision==0.13.1
 wget==3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ jupyterlab==1.2.21
 sphinx==3.5.4
 sphinx-rtd-theme==0.5.2
 recommonmark==0.7.1
+protobuf==3.20.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
-pytest==6.2.3
-tox==3.23.0
-jupyterlab==1.2.21
-sphinx==3.5.4
-sphinx-rtd-theme==0.5.2
-recommonmark==0.7.1
+pytest>=6.2.3, ==6.2.*
+tox>=3.23.0
+jupyterlab>=1.2.21
+sphinx>=3.5.4
+sphinx-rtd-theme>=0.5.2
+recommonmark>=0.7.1
 protobuf==3.20.2

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ with open(path.join(this_directory, 'README.md'), 'r') as f:
     long_description = f.read()
 
 requirements = [
-  "matplotlib==3.3.4",
-  "numpy==1.19.5",
-  "pandas==1.1.5",
-  "torch==1.12.1",
-  "tensorboard==2.5.0",
-  "torchvision==0.13.1",
-  "wget==3.2"
+  "matplotlib>=3.3.4",
+  "numpy>=1.19.5",
+  "pandas>=1.1.5",
+  "torch>=1.12.1",
+  "tensorboard>=2.5.0",
+  "torchvision>=0.13.1",
+  "wget>=3.2"
 ]
 
 setup(name='vegans',

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ requirements = [
   "matplotlib==3.3.4",
   "numpy==1.19.5",
   "pandas==1.1.5",
-  "torch==1.8.1",
+  "torch==1.12.1",
   "tensorboard==2.5.0",
-  "torchvision==0.9.1",
+  "torchvision==0.13.1",
   "wget==3.2"
 ]
 


### PR DESCRIPTION
Loosens up requirements, allowing some newer versions of things. NB: I tried to follow the advice of running `cd test && pytest --gpu` but got an "unrecognized arguments" error:

```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --gpu
  inifile: None
  rootdir: /home/daniel/vegans
```